### PR TITLE
bug: allow FRACTALE_LLM_PROVIDER to set backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The following variables can be set in the environment.
 | `OPENAI_API_KEY` | API Key for an OpenAI model | unset |
 | `OPENAI_BASE_URL` | Base url for OpenAI | unset |
 
+Note that for provider, you can also designate on the command line. The default is Gemini (`gemini`). To change:
+
+```bash
+fractale agent --backend openai ./examples/plans/transform-retry.yaml
+```
+
 ### Agents
 
 The `fractale agent` command provides means to run build, job generation, and deployment agents.

--- a/fractale/core/config.py
+++ b/fractale/core/config.py
@@ -17,8 +17,8 @@ class ModelConfig:
         context = context or {}
 
         # The llm provider is the backend
-        provider = context.get("backend") or os.environ.get("LLM_PROVIDER", "gemini")
-        model = context.get("model") or os.environ.get("LLM_MODEL")
+        provider = context.get("backend") or os.environ.get("FRACTALE_LLM_PROVIDER", "gemini")
+        model = context.get("model") or os.environ.get("FRACTALE_LLM_MODEL")
 
         # I'm not sure I like this approach yet. The model config here would discover
         # credentials from the environment each time is it init'd. Is that something

--- a/fractale/engines/__init__.py
+++ b/fractale/engines/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from fractale.core.plan import Plan
 
 
@@ -10,6 +12,9 @@ def get_engine(plan, engine="native", backend="gemini", ui=None, max_attempts=5,
     """
     # This is loading the plan path
     plan = Plan(plan)
+
+    # Config discovers from environment
+    os.environ["FRACTALE_LLM_PROVIDER"] = backend
 
     # State machine orchestration
     if engine == "native":


### PR DESCRIPTION
Right now, the `--backend` setting is not correctly taking from the command line, and the expectation is to come from the environment. This fixes the `fractale agent` command to allow this parameter, and also will accept from `FRACTALE_LLM_PROVIDER`.